### PR TITLE
work with 2-strain vcf

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -587,14 +587,14 @@ pub fn evaluate_rec<'a>(rh: &RecHolder,
     }
     // sometimes deletions are represented with an empty ALT column
     // the VCF library returns a alleles with len 1 here
-    let REF = alleles[0].to_owned()
-    let ALT = match alleles.len() {
+    let refbase = alleles[0].to_owned();
+    let altbase = match alleles.len() {
         1 => Vec::new(),
         _ => alleles[1].to_owned()
     };
 
     let mut fa = fasta::IndexedReader::from_file(&rh.fasta_file)?;
-    let (rref, alt) = construct_haplotypes(&mut fa, &locus, &REF, &ALT, rh.padding);
+    let (rref, alt) = construct_haplotypes(&mut fa, &locus, &refbase, &altbase, rh.padding);
 
     let haps = VariantHaps {
         locus: Locus { chrom: chr, start: locus.start, end: locus.end },
@@ -836,8 +836,8 @@ pub fn read_locus(fa: &mut fasta::IndexedReader<File>,
 #[inline(never)]
 pub fn construct_haplotypes(fa: &mut fasta::IndexedReader<File>,
                             locus: &Locus, 
-                            REF: &[u8],
-                            ALT: &[u8], 
+                            refbase: &[u8],
+                            altbase: &[u8], 
                             padding: u32) -> (Vec<u8>, Vec<u8>)
 {
     let chrom_len = chrom_len(&locus.chrom, fa).unwrap();
@@ -851,7 +851,7 @@ pub fn construct_haplotypes(fa: &mut fasta::IndexedReader<File>,
         
         let mut alt_hap = Vec::new();
         alt_hap.extend(get_range(locus.start.saturating_sub(padding), locus.start));
-        alt_hap.extend(ALT);
+        alt_hap.extend(altbase);
         alt_hap.extend(get_range(locus.end, min(locus.end + padding, chrom_len as u32)));
         alt_hap
     };
@@ -865,7 +865,7 @@ pub fn construct_haplotypes(fa: &mut fasta::IndexedReader<File>,
         
         let mut alt_hap = Vec::new();
         ref_hap.extend(get_range(locus.start.saturating_sub(padding), locus.start));
-        ref_hap.extend(REF);
+        ref_hap.extend(refbase);
         ref_hap.extend(get_range(locus.end, min(locus.end + padding, chrom_len as u32)));
         ref_hap
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -587,13 +587,14 @@ pub fn evaluate_rec<'a>(rh: &RecHolder,
     }
     // sometimes deletions are represented with an empty ALT column
     // the VCF library returns a alleles with len 1 here
-    let alt = match alleles.len() {
+    let REF = alleles[0].to_owned()
+    let ALT = match alleles.len() {
         1 => Vec::new(),
         _ => alleles[1].to_owned()
     };
 
     let mut fa = fasta::IndexedReader::from_file(&rh.fasta_file)?;
-    let (rref, alt) = construct_haplotypes(&mut fa, &locus, &alt, rh.padding);
+    let (rref, alt) = construct_haplotypes(&mut fa, &locus, &REF, &ALT, rh.padding);
 
     let haps = VariantHaps {
         locus: Locus { chrom: chr, start: locus.start, end: locus.end },
@@ -835,7 +836,8 @@ pub fn read_locus(fa: &mut fasta::IndexedReader<File>,
 #[inline(never)]
 pub fn construct_haplotypes(fa: &mut fasta::IndexedReader<File>,
                             locus: &Locus, 
-                            alt: &[u8], 
+                            REF: &[u8],
+                            ALT: &[u8], 
                             padding: u32) -> (Vec<u8>, Vec<u8>)
 {
     let chrom_len = chrom_len(&locus.chrom, fa).unwrap();
@@ -849,12 +851,26 @@ pub fn construct_haplotypes(fa: &mut fasta::IndexedReader<File>,
         
         let mut alt_hap = Vec::new();
         alt_hap.extend(get_range(locus.start.saturating_sub(padding), locus.start));
-        alt_hap.extend(alt);
+        alt_hap.extend(ALT);
         alt_hap.extend(get_range(locus.end, min(locus.end + padding, chrom_len as u32)));
         alt_hap
     };
+    
+    let ref_hap = {
+        let mut get_range = |s,e| {
+            let fetch_locus = Locus { chrom: locus.chrom.clone(), start: s, end: e };
+            let (bytes, _) = read_locus(fa, &fetch_locus, 0, 0);
+            bytes
+        };
+        
+        let mut alt_hap = Vec::new();
+        ref_hap.extend(get_range(locus.start.saturating_sub(padding), locus.start));
+        ref_hap.extend(REF);
+        ref_hap.extend(get_range(locus.end, min(locus.end + padding, chrom_len as u32)));
+        ref_hap
+    };
 
-    let (ref_hap, _) = read_locus(fa, locus, padding, padding);
+    //let (ref_hap, _) = read_locus(fa, locus, padding, padding);
     debug!("{}:{}-{} -- ref: {} alt: {}", locus.chrom, locus.start, locus.end, 
                                           String::from_utf8(ref_hap.clone()).unwrap(), 
                                           String::from_utf8(alt_hap.clone()).unwrap());


### PR DESCRIPTION
Hi,
I'm working with a allele-specific expression analysis, while neither of two strains was the reference strain (mouse: PWK * C57). That is, both of them has SNP sites compared with mm10 ref-genome. 

I construct my own VCF file from all-strain vcf file from [here](ftp://ftp-mouse.sanger.ac.uk/current_snps), using the PWK base as REF and C57 base as ALT:
```
my.vcf:
#     pwk   c57
# ... REF   ALT ...
      A     C 
      ...
```

My problem is, when PWK and mm10 are different at a site, and my bam read is same as PWK:
```
(ref) pwk: .....A.....
(alt) c57: .....C.....
(fa) mm10: .....C.....
(bam_read): ....A....
```
Using original `vartrix`, the `ref_hap` will be `...C...(from fa-mm10)`, and the `alt_hap` will be `...C...(from alt-c57)`. Now, the read is mapped to `ref_hap` and `alt_hap` with same score, leading this read to become `UNKOWN`. And I got many
`Variant at index 4631 has multiple unknown reads at barcode index 12943` error.

So, my solution is creating `ref_hap` from vcf ref base directly, instead of creating it from the fasta reference. I have built my `main.rs` code and it works fine for my 2-strain problem. 